### PR TITLE
Add Case: isCaseIdentifier(identifier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,30 @@ const field1 = fields('complex1.field1');
 const field2 = fields('field2');
 ```
 
+#### isCaseIdentifier(identifier)
+
+Validate that a string or number is a valid QuickCase identifier.
+
+##### Arguments
+
+| Name | Type | Description |
+|------|------|-------------|
+| identifier | number|string | Required. Identifier to validate |
+
+##### Returns
+
+`true` when identifier is valid (16 digits with correct check digit); `false` otherwise.
+
+#### Example
+
+```javascript
+import {isCaseIdentifier} from '@quickcase/node-toolkit';
+
+isCaseIdentifier('1234') // > false - Not 16 digits
+isCaseIdentifier('1234123412341234') // > false - Incorrect check digit
+isCaseIdentifier('1234123412341238') // > true - Correct check digit
+```
+
 ### Field
 
 #### isNo(value)

--- a/modules/case.js
+++ b/modules/case.js
@@ -31,3 +31,24 @@ const field = (from) => (pathElements) => {
     }
   }
 };
+
+/**
+ * Check whether a string or number is a valid QuickCase case identifier.
+ *
+ * @param {string|number} identifier Identifier to validate
+ * @return {boolean} Whether the identifier is valid
+ */
+export const isCaseIdentifier = (identifier) => /\d{16}/.test(identifier) && checkDigit(identifier);
+
+const checkDigit = (number) => luhnSum(number) % 10 === 0;
+
+const luhnSum = (number) => String(number).split('')
+                                          .reverse()
+                                          .map(Number)
+                                          .reduce((acc, cur, i) => acc + luhnDigit(cur, i), 0);
+
+const luhnDigit = (digit, index) => index % 2 === 0 ? digit : luhnDouble(digit);
+
+const luhnDouble = (digit) => luhnCap(digit * 2);
+
+const luhnCap = (digit) => digit > 9 ? digit - 9 : digit;

--- a/modules/case.test.js
+++ b/modules/case.test.js
@@ -1,4 +1,4 @@
-import {fieldExtractor} from './case';
+import {fieldExtractor, isCaseIdentifier} from './case';
 
 describe('fieldExtractor', () => {
   test('should extract field from case `data`', () => {
@@ -46,5 +46,31 @@ describe('fieldExtractor', () => {
     const fieldValue = fieldExtractor(aCase)('level1.level2');
     expect(fieldValue).toBeUndefined();
   });
+});
 
+describe('isCaseIdentifier', () => {
+  test('should be false when length is less than 16 characters', () => {
+    expect(isCaseIdentifier('1234')).toBe(false);
+  });
+
+  test('should be false when length is more than 16 characters', () => {
+    expect(isCaseIdentifier('12345678901234567890')).toBe(false);
+  });
+
+  test('should be false when contains characters others than digits', () => {
+    expect(isCaseIdentifier('123412341234123A')).toBe(false);
+  });
+
+  test('should be false when check digit does not match', () => {
+    expect(isCaseIdentifier('1234123412341234')).toBe(false);
+  });
+
+  test.each([
+    '1234123412341238',
+    '1579871203156511',
+    '1579873635774838',
+    1579873635774838,
+  ])('should be true when 16-digit number with correct check digit: %s', (identifier) => {
+    expect(isCaseIdentifier(identifier)).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes #9

```javascript
import {isCaseIdentifier} from '@quickcase/node-toolkit';

isCaseIdentifier('1234') // > false - Not 16 digits
isCaseIdentifier('1234123412341234') // > false - Incorrect check digit
isCaseIdentifier('1234123412341238') // > true - Correct check digit
```