### PR TITLE
Add Case: fetchCase(httpClient)(caseId)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,40 @@ npm i @quickcase/node-toolkit
 
 ### Case
 
+#### fetchCase(httpClient)(caseId)()
+
+Fetch a case from QuickCase Data Store.
+
+##### Arguments
+
+| Name | Type | Description |
+|------|------|-------------|
+| httpClient | object| Required. A configured, ready-to-use HTTP client from `@quickcase/node-toolkit` |
+| caseId | string | Required. 16-digit unique case identifier |
+
+##### Returns
+
+`Promise` resolved with the case matching the given identifier.
+
+#### Example
+
+```javascript
+import {fetchCase, httpClient} from '@quickcase/node-toolkit';
+
+// A configured `httpClient` is required to fetch case
+const searchClient = httpClient('http://data-store:4452')(() => Promise.resolve('access-token'));
+
+const aCase = await fetchCase('1234123412341238')();
+/*
+{
+  id: '1234123412341238',
+  state: 'Active',
+  data: {...},
+  ...
+}
+*/
+```
+
 #### fieldExtractor(aCase)(path)
 
 Extract the value of a field from the given case.

--- a/modules/case.js
+++ b/modules/case.js
@@ -1,4 +1,17 @@
 /**
+ * Fetch a case from QuickCase Data Store by ID.
+ *
+ * @param {httpClient} http Configured, ready-to-use HTTP client
+ * @param {string|number} caseId 16-digit unique case identifier
+ * @return {Promise} Promise resolved with the case for the given identifier.
+ */
+export const fetchCase = (http) => (caseId) => async () => {
+  const url = `/cases/${caseId}`;
+  const res = await http.get(url);
+  return res.data;
+};
+
+/**
  * Given a case and the path to a field, extract the value of that field. When accessing case fields, this approach should
  * be preferred as a way to avoid hard references to case fields through the use of a fields map.
  *

--- a/modules/case.test.js
+++ b/modules/case.test.js
@@ -1,4 +1,23 @@
-import {fieldExtractor, isCaseIdentifier} from './case';
+import {fetchCase, fieldExtractor, isCaseIdentifier} from './case';
+
+describe('fetchCase', () => {
+  test('should fetch case by id', async () => {
+    const caseId = '1234123412341238';
+    const resData = {
+      id: caseId,
+      data: {},
+    };
+    const httpStub = {
+      get: (url) => {
+        expect(url).toEqual(`/cases/${caseId}`);
+        return Promise.resolve({data: resData});
+      },
+    };
+
+    const actualData = await fetchCase(httpStub)(caseId)();
+    expect(actualData).toEqual(resData);
+  });
+});
 
 describe('fieldExtractor', () => {
   test('should extract field from case `data`', () => {


### PR DESCRIPTION
Fixes #8

```javascript
import {fetchCase, httpClient} from '@quickcase/node-toolkit';

// A configured `httpClient` is required to fetch case
const searchClient = httpClient('http://data-store:4452')(() => Promise.resolve('access-token'));

const aCase = await fetchCase('1234123412341238')();
/*
{
  id: '1234123412341238',
  state: 'Active',
  data: {...},
  ...
}
*/
```