### PR TITLE
Fix document metadata contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Creates a new document upload URL.
 | metadata | object | Required. Document metadata, will be used for access control. See below |
 
 `metadata`:
+* `filename`: String. Custom name for the file, used to name downloads
 * `organisation`: String. Organisation ID
 * `caseType`: String. Case type ID
 * `case`: String. Case 16-digit reference
@@ -397,8 +398,10 @@ import {createDocument, httpClient} from '@quickcase/node-toolkit';
 const client = httpClient('http://document-store:3333')(() => Promise.resolve('access-token'));
 
 const metadata = {
+  filename: 'someFile.pdf',
   organisation: 'org1',
   caseType: 'caseType1',
+  case: '1234123412341238',
   field: 'field1',
 };
 const docUpload = await createDocument(client)(metadata);

--- a/modules/document.js
+++ b/modules/document.js
@@ -1,5 +1,6 @@
 /**
  * @typedef {object} DocumentMetadata
+ * @property {string} filename Name of the file, to be used as custom name for downloads
  * @property {string} organisation Organisation ID
  * @property {string} caseType Case Type ID
  * @property {string} case Case 16-digit reference

--- a/modules/document.test.js
+++ b/modules/document.test.js
@@ -11,6 +11,7 @@ describe('createDocument', () => {
         expect(url).toEqual('/documents');
         expect(body).toEqual({
           metadata: {
+            filename: 'someFile.pdf',
             organisation: 'org1',
             caseType: 'caseType1',
             case: '1234123412341238',
@@ -22,6 +23,7 @@ describe('createDocument', () => {
     };
 
     const metadata = {
+      filename: 'someFile.pdf',
       organisation: 'org1',
       caseType: 'caseType1',
       case: '1234123412341238',


### PR DESCRIPTION
* Pass metadata as `metadata` property instead of at body's root
* Document new metadata item `filename`