### PR TITLE
Add linter workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,32 @@
+---
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+# Start the job on all push
+on:
+  push:
+    branches-ignore:
+      - 'main'
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Lint Code Base
+        uses: docker://github/super-linter:v2.1.1
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          VALIDATE_JAVASCRIPT_ES: true 
+          VALIDATE_JSON: true
+          VALIDATE_YAML: true
+


### PR DESCRIPTION
Fixes #50 

Lint all pushed commits to non-main branch using Github's Super-Linter. To make check quicker, only new and edited files compared to default branch `main` are taken into consideration.