### PR TITLE
HttpClient: Add optional param for custom Axios instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ isYes('No'); // false
 
 ### HTTP Client
 
-#### httpClient(baseUrl)(accessTokenProvider)
+#### httpClient(baseUrl, axiosInstance = axios)(accessTokenProvider)
 
 Create a configured instance of an HTTP client, based on [Axios](https://github.com/axios/axios).
 
@@ -549,7 +549,8 @@ Create a configured instance of an HTTP client, based on [Axios](https://github.
 
 | Name | Type | Description |
 |------|------|-------------|
-| baseUrl | string| Required. Base URL to use for HTTP requests |
+| baseUrl | string | Required. Base URL to use for HTTP requests |
+| axiosInstance | Axios | Optional. Custom instance of Axios, created by `axios.create()`. Defaults to global `axios` instance. |
 | accessTokenProvider | function | Required. Function returning a `Promise` resolved with a valid access token |
 
 ##### Returns

--- a/src/modules/http-client.js
+++ b/src/modules/http-client.js
@@ -1,18 +1,26 @@
 import axios from 'axios';
 
-export const httpClient = (baseUrl) => (accessTokenProvider)  => Object.freeze({
-  get: getRequest(urlBuilder(baseUrl))(accessTokenProvider),
-  post: postRequest(urlBuilder(baseUrl))(accessTokenProvider),
-  put: putRequest(urlBuilder(baseUrl))(accessTokenProvider),
+/**
+ * @callback AccessTokenProvider
+ * @return {Promise} Promise resolved with a valid OAuth2 Bearer token
+ */
+
+/**
+ * Create an instance of a configured httpClient.
+ *
+ * @param {string} baseUrl Root URL to which relative path will be appended when performing requests.
+ * @param {Axios} axiosInstance Optional. Custom Axios instance as created by `axios.create()`. Defaults to global `axios` instance.
+ * @param {AccessTokenProvider} accessTokenProvider Async function returning an OAuth2 Bearer token.
+ */
+export const httpClient = (baseUrl, axiosInstance = axios) => (accessTokenProvider) => Object.freeze({
+  get: emptyRequest(axiosInstance.get)(urlBuilder(baseUrl))(accessTokenProvider),
+  post: bodyRequest(axiosInstance.post)(urlBuilder(baseUrl))(accessTokenProvider),
+  put: bodyRequest(axiosInstance.put)(urlBuilder(baseUrl))(accessTokenProvider),
 });
 
-const getRequest = (url) => (accessTokenProvider) => async (relativeUrl) => axios.get(url(relativeUrl), headers(await authorization(accessTokenProvider)));
+const emptyRequest = (axiosFn) => (url) => (accessTokenProvider) => async (relativeUrl) => axiosFn(url(relativeUrl), headers(await authorization(accessTokenProvider)));
 
 const bodyRequest = (axiosFn) => (url) => (accessTokenProvider) => async (relativeUrl, body) => axiosFn(url(relativeUrl), body, headers(await authorization(accessTokenProvider)));
-
-const postRequest = bodyRequest(axios.post);
-
-const putRequest = bodyRequest(axios.put);
 
 const urlBuilder = (baseUrl) => (relativeUrl) => baseUrl + relativeUrl;
 

--- a/src/modules/http-client.test.js
+++ b/src/modules/http-client.test.js
@@ -38,4 +38,24 @@ describe('httpClient', () => {
     expect(resp).toEqual(expectedResp);
     expect(axios.put).toHaveBeenCalledWith('http://data-store:4452/path/to/resource', body,{headers: {Authorization: 'Bearer access-token-123'}});
   });
+
+  test('should accept custom axios instance', async () => {
+    const customAxios = {
+      get: jest.fn().mockResolvedValue({status: 200}),
+      post: jest.fn().mockResolvedValue({status: 201}),
+      put: jest.fn().mockResolvedValue({status: 202}),
+    };
+
+    const customClient = httpClient(baseUrl, customAxios)(tokenProviderStub);
+
+    const [getRes, postRes, putRes] = await Promise.all([
+      customClient.get('/path/to/get'),
+      customClient.post('/path/to/post'),
+      customClient.put('/path/to/put'),
+    ]);
+
+    expect(getRes).toEqual({status: 200});
+    expect(postRes).toEqual({status: 201});
+    expect(putRes).toEqual({status: 202});
+  });
 });


### PR DESCRIPTION
Resolves #63 

Optionally accept a custom Axios instance to be used for HttpClient's requests, allowing custom configuration (eg. proxy) to be specified.