### PR TITLE
Case: Add upcateCase(http)(caseId)(eventId)(payload)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,50 @@ isCaseIdentifier36('0fl6udxa2qj') // > true if the base36 string is a valid case
 isCaseIdentifier36('xa2qj') // > false if the base36 string is not a valid case identifier
 ```
 
+#### updateCase(httpClient)(caseTypeId)(eventId)(payload)
+
+Update/progress an existing case in QuickCase Data Store.
+
+##### Arguments
+
+| Name | Type | Description |
+|------|------|-------------|
+| httpClient | object| Required. A configured, ready-to-use HTTP client from `@quickcase/node-toolkit` |
+| caseId | string | Required. 16-digit unique case identifier |
+| eventId | string | Required. Unique event trigger identifier to use for update |
+| payload | description | Optional. Case data and event description |
+
+`payload`:
+* `data`: Optional object formed of key/value pairs of case fields to add/edit the case
+* `summary`: Optional short sentence justifying the case update
+* `description`: Optional longer explanation of the case update
+
+##### Returns
+
+`Promise` resolved with the updated case.
+
+#### Example
+
+```javascript
+import {updateCase, httpClient} from '@quickcase/node-toolkit';
+
+// A configured `httpClient` is required to create a case
+const client = httpClient('http://data-store:4452')(() => Promise.resolve('access-token'));
+
+const aCase = await updateCase(client)('aCaseType')('anEvent')({
+  data: {field1: 'value1'},
+  summary: 'Updated case',
+});
+/*
+{
+  id: '1234123412341238',
+  state: 'Updated',
+  data: {field1: 'value1'},
+  ...
+}
+*/
+```
+
 ### Case Access
 
 #### grantGroupAccess(httpClient)(caseId)(groupId)(...caseRoles)

--- a/src/modules/case.js
+++ b/src/modules/case.js
@@ -3,9 +3,9 @@ const RADIX_36 = 36;
 /**
  * @typedef CreatePayload
  * @type {object}
- * @property {object} data optional key value pairs of case fields for the new case
- * @property {string} summary optional motivation of the case creation
- * @property {string} age optional longer explanation of the case creation
+ * @property {object} data Optional key value pairs of case fields for the new case
+ * @property {string} summary Optional motivation of the case creation
+ * @property {string} description Optional longer explanation of the case creation
  */
 
 /**
@@ -15,7 +15,7 @@ const RADIX_36 = 36;
  * @param {string} caseTypeId Unique case type identifier
  * @param {string} eventId Unique event trigger identifier to use for creation
  * @param {CreatePayload} payload Object formed of optional `data`, `summary` and `description`
- * @return {Promise} Promise resolved with the case for the given identifier.
+ * @return {Promise} Promise resolved with the created case
  */
 export const createCase = (http) => (caseTypeId) => (eventId) => async (payload = {}) => {
   const {data: {token}} = await http.get(`/case-types/${caseTypeId}/event-triggers/${eventId}`);
@@ -131,3 +131,34 @@ export const idFrom36 = (base36String) => parseInt(base36String, RADIX_36).toStr
  * @returns {boolean} - true/false
  */
 export const isCaseIdentifier36 = (base36String) => isCaseIdentifier(idFrom36(base36String));
+
+/**
+ * @typedef UpdatePayload
+ * @type {object}
+ * @property {object} data Optional key value pairs of case fields to add/edit the case
+ * @property {string} summary Optional motivation of the case update
+ * @property {string} description Optional longer explanation of the case update
+ */
+
+/**
+ * Update/progress an existing case in QuickCase Data Store.
+ *
+ * @param {httpClient} http Configured, ready-to-use HTTP client
+ * @param {string} caseId 16-digit unique case identifier
+ * @param {string} eventId Unique event trigger identifier to use for update
+ * @param {UpdatePayload} payload Object formed of optional `data`, `summary` and `description`
+ * @return {Promise} Promise resolved with the updated case
+ */
+export const updateCase = (http) => (caseId) => (eventId) => async (payload = {}) => {
+  const {data: {token}} = await http.get(`/cases/${caseId}/event-triggers/${eventId}`);
+  const updateRes = await http.post(`/cases/${caseId}/events`, {
+    data: payload.data,
+    event: {
+      id: eventId,
+      summary: payload.summary,
+      description: payload.description,
+    },
+    event_token: token,
+  });
+  return updateRes.data;
+};

--- a/src/modules/case.test.js
+++ b/src/modules/case.test.js
@@ -6,6 +6,7 @@ import {
   idTo36,
   isCaseIdentifier,
   isCaseIdentifier36,
+  updateCase,
 } from './case';
 
 describe('fetchCase', () => {
@@ -205,6 +206,85 @@ describe('createCase', () => {
     expect(createdCase).toEqual({
       id: caseId,
       data: {},
+    });
+  });
+});
+
+describe('updateCase', () => {
+  test('should update a case for given case ID and event', async () => {
+    const caseId = '1234123412341238';
+    const eventId = 'anEvent';
+    const token = 'trigger-token';
+    const payload = {
+      data: {field1: 'value1'},
+      summary: 'A summary',
+      description: 'A description',
+    };
+    const httpStub = {
+      get: (url) => {
+        expect(url).toEqual(`/cases/${caseId}/event-triggers/${eventId}`);
+        return Promise.resolve({data: {token}});
+      },
+      post: (url, body) => {
+        expect(url).toEqual(`/cases/${caseId}/events`);
+        expect(body).toEqual({
+          data: payload.data,
+          event: {
+            id: eventId,
+            summary: payload.summary,
+            description: payload.description,
+          },
+          event_token: token,
+        });
+        return Promise.resolve({data: {
+          id: caseId,
+          data: body.data,
+        }});
+      },
+    };
+
+    const updatedCase = await updateCase(httpStub)(caseId)(eventId)(payload);
+    expect(updatedCase).toEqual({
+      id: caseId,
+      data: payload.data,
+    });
+  });
+
+  test('should update a case for given case ID and event without payload', async () => {
+    const caseId = '1234123412341238';
+    const eventId = 'anEvent';
+    const token = 'trigger-token';
+    const httpStub = {
+      get: (url) => {
+        expect(url).toEqual(`/cases/${caseId}/event-triggers/${eventId}`);
+        return Promise.resolve({data: {token}});
+      },
+      post: (url, body) => {
+        expect(url).toEqual(`/cases/${caseId}/events`);
+        expect(body).toEqual({
+          data: undefined,
+          event: {
+            id: eventId,
+            summary: undefined,
+            description: undefined,
+          },
+          event_token: token,
+        });
+        return Promise.resolve({data: {
+          id: caseId,
+          data: {
+            field1: 'value1',
+          },
+        }});
+      },
+    };
+
+    const updatedCase = await updateCase(httpStub)(caseId)(eventId)();
+    expect(updatedCase).toEqual({
+      id: caseId,
+      data: {
+        field1: 'value1',
+      },
     });
   });
 });


### PR DESCRIPTION
Fixes #68

```javascript
import {updateCase, httpClient} from '@quickcase/node-toolkit';
// A configured `httpClient` is required to create a case
const client = httpClient('http://data-store:4452')(() => Promise.resolve('access-token'));
const aCase = await updateCase(client)('aCaseType')('anEvent')({
  data: {field1: 'value1'},
  summary: 'Updated case',
});
/*
{
  id: '1234123412341238',
  state: 'Updated',
  data: {field1: 'value1'},
  ...
}
*/
```