### PR TITLE
Add support for collection to fieldExtractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ const aCase = {
   data: {
     complex1: { field1: 'value1' },
     field2: 'value2',
+    collection3: [
+      {id: '123', value: {field2: 'value3'}},
+      {id: '456', value: {field2: 'value4'}},
+    ]
   }
 };
 
@@ -174,6 +178,9 @@ const fields = fieldExtractor(aCase);
 // Extract single values
 const value1 = fields('complex1.field1');
 const value2 = fields('field2');
+
+// Extract from collections
+const value3 = fields('collection3[0].value.field2'); // By index
 
 // Bulk extract as array
 const values = fields(['complex1.field1', 'field2', 'field3']);

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ const value2 = fields('field2');
 
 // Extract from collections
 const value3 = fields('collection3[0].value.field2'); // By index
+const value4 = fields('collection3[id:456].value.field2'); // By id
 
 // Bulk extract as array
 const values = fields(['complex1.field1', 'field2', 'field3']);

--- a/src/modules/case.test.js
+++ b/src/modules/case.test.js
@@ -181,6 +181,21 @@ describe('fieldExtractor', () => {
     expect(fieldValues).toBeUndefined();
   });
 
+  test('should extract collection item as undefined when invalid index', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [
+            {id: '123', value: 'value1'},
+          ],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)('level1.level2[a].value');
+    expect(fieldValues).toBeUndefined();
+  });
+
   test('should extract collection item as undefined when not collection', () => {
     const aCase = {
       data: {
@@ -217,6 +232,61 @@ describe('fieldExtractor', () => {
     };
 
     const fieldValues = fieldExtractor(aCase)('level1.level2[0].value');
+    expect(fieldValues).toBeUndefined();
+  });
+
+  test('should extract simple collection item from case `data` using item ID', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [
+            {id: '123', value: 'value1'},
+            {id: '456', value: 'value2'},
+            {id: '789', value: 'value3'},
+          ],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)([
+      'level1.level2[id:456].value',
+      'level1.level2[id:789].value',
+      'level1.level2[id:123].value',
+    ]);
+    expect(fieldValues).toEqual([
+      'value2',
+      'value3',
+      'value1',
+    ]);
+  });
+
+  test('should extract complex collection item from case `data` using item ID', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [
+            {id: '123', value: {key: 'value1'}},
+          ],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)('level1.level2[id:123].value.key');
+    expect(fieldValues).toEqual('value1');
+  });
+
+  test('should extract collection item as undefined when invalid ID', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [
+            {id: '123', value: 'value1'},
+          ],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)('level1.level2[id:456].value');
     expect(fieldValues).toBeUndefined();
   });
 

--- a/src/modules/case.test.js
+++ b/src/modules/case.test.js
@@ -68,6 +68,17 @@ describe('fieldExtractor', () => {
     expect(fieldValue).toBeUndefined();
   });
 
+  test('should extract field as undefined when parent element is null', () => {
+    const aCase = {
+      data: {
+        level1: null
+      }
+    };
+
+    const fieldValue = fieldExtractor(aCase)('level1.level2');
+    expect(fieldValue).toBeUndefined();
+  });
+
   test('should extract field as undefined when case has no data', () => {
     const aCase = {};
 
@@ -112,6 +123,101 @@ describe('fieldExtractor', () => {
       value2: 'value2',
       notFound2: undefined,
     });
+  });
+
+  test('should extract simple collection item from case `data` using item index', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [
+            {id: '123', value: 'value1'},
+            {id: '456', value: 'value2'},
+            {id: '789', value: 'value3'},
+          ],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)([
+      'level1.level2[2].value',
+      'level1.level2[1].value',
+      'level1.level2[0].value',
+    ]);
+    expect(fieldValues).toEqual([
+      'value3',
+      'value2',
+      'value1',
+    ]);
+  });
+
+  test('should extract complex collection item from case `data` using item index', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [
+            {id: '123', value: {key: 'value1'}},
+            {id: '456', value: {key: 'value2'}},
+          ],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)('level1.level2[1].value.key');
+    expect(fieldValues).toEqual('value2');
+  });
+
+  test('should extract collection item as undefined when out of range', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [
+            {id: '123', value: 'value1'},
+          ],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)('level1.level2[1].value');
+    expect(fieldValues).toBeUndefined();
+  });
+
+  test('should extract collection item as undefined when not collection', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: 'hello',
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)('level1.level2[0].value');
+    expect(fieldValues).toBeUndefined();
+  });
+
+  test('should extract collection item as undefined when item malformed', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [true],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)('level1.level2[0].value');
+    expect(fieldValues).toBeUndefined();
+  });
+
+  test('should extract collection item as undefined when null', () => {
+    const aCase = {
+      data: {
+        level1: {
+          level2: [null],
+        }
+      }
+    };
+
+    const fieldValues = fieldExtractor(aCase)('level1.level2[0].value');
+    expect(fieldValues).toBeUndefined();
   });
 
   test('should throw error if provided path is not of a supported type', () => {


### PR DESCRIPTION
Resolves #130 

Example:
```javascript
import {fieldExtractor} from '@quickcase/node-toolkit';

const aCase = {
  id: '1234123412341234',
  state: 'Open',
  data: {
    collection3: [
      {id: '123', value: {field2: 'value3'}},
      {id: '456', value: {field2: 'value4'}},
    ]
  }
};

// Prepare fields for extraction
const fields = fieldExtractor(aCase);

// Extract from collections
const value3 = fields('collection3[0].field2'); // By index
const value4 = fields('collection3[id:456].field2'); // By id
```