### PR TITLE
Merge event trigger case data on case create and update

### DIFF
--- a/src/modules/case.js
+++ b/src/modules/case.js
@@ -19,9 +19,9 @@ const COLLECTION_ITEM_PATTERN = /^(?<name>[^\[\]]+)(?:\[(?:(?<colIndex>\d+)|id:(
  * @return {Promise} Promise resolved with the created case
  */
 export const createCase = (http) => (caseTypeId) => (eventId) => async (payload = {}) => {
-  const {data: {token}} = await http.get(`/case-types/${caseTypeId}/event-triggers/${eventId}`);
+  const {data: {token, case_details: {case_data: eventTriggerCaseData}}} = await http.get(`/case-types/${caseTypeId}/event-triggers/${eventId}`);
   const createRes = await http.post(`/case-types/${caseTypeId}/cases`, {
-    data: payload.data,
+    data: {...eventTriggerCaseData, ...payload.data},
     event: {
       id: eventId,
       summary: payload.summary,
@@ -200,9 +200,9 @@ export const isCaseIdentifier36 = (base36String) => isCaseIdentifier(idFrom36(ba
  * @return {Promise} Promise resolved with the updated case
  */
 export const updateCase = (http) => (caseId) => (eventId) => async (payload = {}) => {
-  const {data: {token}} = await http.get(`/cases/${caseId}/event-triggers/${eventId}`);
+  const {data: {token, case_details: {case_data: eventTriggerCaseData}}} = await http.get(`/cases/${caseId}/event-triggers/${eventId}`);
   const updateRes = await http.post(`/cases/${caseId}/events`, {
-    data: payload.data,
+    data: {...eventTriggerCaseData, ...payload.data},
     event: {
       id: eventId,
       summary: payload.summary,

--- a/src/modules/case.test.js
+++ b/src/modules/case.test.js
@@ -374,12 +374,15 @@ describe('createCase', () => {
     const httpStub = {
       get: (url) => {
         expect(url).toEqual(`/case-types/${caseTypeId}/event-triggers/${eventId}`);
-        return Promise.resolve({data: {token}});
+        return Promise.resolve({data: {token, case_details: {case_data: {field1: 'value0', field2: 'value2'}}}});
       },
       post: (url, body) => {
         expect(url).toEqual(`/case-types/${caseTypeId}/cases`);
         expect(body).toEqual({
-          data: payload.data,
+          data: {
+            field1: 'value1',
+            field2: 'value2',
+          },
           event: {
             id: eventId,
             summary: payload.summary,
@@ -397,7 +400,10 @@ describe('createCase', () => {
     const createdCase = await createCase(httpStub)(caseTypeId)(eventId)(payload);
     expect(createdCase).toEqual({
       id: caseId,
-      data: payload.data,
+      data: {
+        field1: 'value1',
+        field2: 'value2',
+      },
     });
   });
 
@@ -409,12 +415,12 @@ describe('createCase', () => {
     const httpStub = {
       get: (url) => {
         expect(url).toEqual(`/case-types/${caseTypeId}/event-triggers/${eventId}`);
-        return Promise.resolve({data: {token}});
+        return Promise.resolve({data: {token, case_details: {case_data: {}}}});
       },
       post: (url, body) => {
         expect(url).toEqual(`/case-types/${caseTypeId}/cases`);
         expect(body).toEqual({
-          data: undefined,
+          data: {},
           event: {
             id: eventId,
             summary: undefined,
@@ -450,12 +456,15 @@ describe('updateCase', () => {
     const httpStub = {
       get: (url) => {
         expect(url).toEqual(`/cases/${caseId}/event-triggers/${eventId}`);
-        return Promise.resolve({data: {token}});
+        return Promise.resolve({data: {token, case_details: {case_data: {field1: 'value0', field2: 'value2'}}}});
       },
       post: (url, body) => {
         expect(url).toEqual(`/cases/${caseId}/events`);
         expect(body).toEqual({
-          data: payload.data,
+          data: {
+            field1: 'value1',
+            field2: 'value2',
+          },
           event: {
             id: eventId,
             summary: payload.summary,
@@ -473,7 +482,10 @@ describe('updateCase', () => {
     const updatedCase = await updateCase(httpStub)(caseId)(eventId)(payload);
     expect(updatedCase).toEqual({
       id: caseId,
-      data: payload.data,
+      data: {
+        field1: 'value1',
+        field2: 'value2',
+      },
     });
   });
 
@@ -484,12 +496,12 @@ describe('updateCase', () => {
     const httpStub = {
       get: (url) => {
         expect(url).toEqual(`/cases/${caseId}/event-triggers/${eventId}`);
-        return Promise.resolve({data: {token}});
+        return Promise.resolve({data: {token, case_details: {case_data: {}}}});
       },
       post: (url, body) => {
         expect(url).toEqual(`/cases/${caseId}/events`);
         expect(body).toEqual({
-          data: undefined,
+          data: {},
           event: {
             id: eventId,
             summary: undefined,


### PR DESCRIPTION
On start of the trigger the case data should be merged with the payload data inorder to retain any case data generated as part of the event trigger