### PR TITLE
Pass custom params for client credentials request

### DIFF
--- a/src/modules/oauth2/client-credentials.js
+++ b/src/modules/oauth2/client-credentials.js
@@ -42,5 +42,6 @@ const getNewToken = async (config) => extractToken(await postToken(config, param
 const extractToken = (response) => response.data.access_token;
 
 const params = (config) => ({
+  ...config,
   grant_type: 'client_credentials',
 });

--- a/src/modules/oauth2/client-credentials.test.js
+++ b/src/modules/oauth2/client-credentials.test.js
@@ -10,6 +10,7 @@ describe('clientAccessTokenProvider', () => {
     tokenEndpoint: 'https://idam/oauth2/token',
     clientId: 'client-123',
     clientSecret: 'secret-123',
+    scope: 'some/scope',
   });
 
   beforeEach(() => {
@@ -27,6 +28,7 @@ describe('clientAccessTokenProvider', () => {
 
       expect(lastPost[0]).toEqual('https://idam/oauth2/token');
       expect(lastPost[1].get('grant_type')).toEqual('client_credentials');
+      expect(lastPost[1].get('scope')).toEqual('some/scope');
       expect(lastPost[2]).toEqual({
         headers: {
           authorization: 'Basic Y2xpZW50LTEyMzpzZWNyZXQtMTIz',


### PR DESCRIPTION
Allow additional query params to be provided via config for client credentials grant.